### PR TITLE
port west-slavic pluralizer from rails

### DIFF
--- a/__tests__/pluralization.westSlavic.test.ts
+++ b/__tests__/pluralization.westSlavic.test.ts
@@ -15,12 +15,9 @@ test("detects few key", () => {
   expect(westSlavic(i18n, 4)).toEqual(["few"]);
 });
 
-test("detects many key", () => {
-});
-
 test("detects other key", () => {
-  expect(westSlavic(i18n, 0)).toEqual(["many"]);
+  expect(westSlavic(i18n, 0)).toEqual(["other"]);
   expect(westSlavic(i18n, 1.1)).toEqual(["other"]);
-  expect(westSlavic(i18n, 5)).toEqual(["many"]);
-  expect(westSlavic(i18n, 6)).toEqual(["many"]);
+  expect(westSlavic(i18n, 5)).toEqual(["other"]);
+  expect(westSlavic(i18n, 6)).toEqual(["other"]);
 });

--- a/__tests__/pluralization.westSlavic.test.ts
+++ b/__tests__/pluralization.westSlavic.test.ts
@@ -1,0 +1,26 @@
+import { I18n } from "../src/I18n";
+import { westSlavic } from "../src/pluralize/westSlavic";
+import { translations } from "./fixtures/translations";
+
+const i18n = new I18n(translations());
+i18n.pluralization.register("cs", westSlavic);
+
+test("detects one key", () => {
+  expect(westSlavic(i18n, 1)).toEqual(["one"]);
+});
+
+test("detects few key", () => {
+  expect(westSlavic(i18n, 2)).toEqual(["few"]);
+  expect(westSlavic(i18n, 3)).toEqual(["few"]);
+  expect(westSlavic(i18n, 4)).toEqual(["few"]);
+});
+
+test("detects many key", () => {
+});
+
+test("detects other key", () => {
+  expect(westSlavic(i18n, 0)).toEqual(["many"]);
+  expect(westSlavic(i18n, 1.1)).toEqual(["other"]);
+  expect(westSlavic(i18n, 5)).toEqual(["many"]);
+  expect(westSlavic(i18n, 6)).toEqual(["many"]);
+});

--- a/src/pluralize/westSlavic.ts
+++ b/src/pluralize/westSlavic.ts
@@ -4,6 +4,7 @@ import { Pluralizer } from "../typing";
 export const westSlavic: Pluralizer = (_i18n: I18n, count: number) => {
   const few = [2, 3, 4];
   let key;
+
   if (count == 1) {
     key = "one";
   } else if (few.includes(count)) {
@@ -11,5 +12,6 @@ export const westSlavic: Pluralizer = (_i18n: I18n, count: number) => {
   } else {
     key = "other";
   }
+
   return [key];
 };

--- a/src/pluralize/westSlavic.ts
+++ b/src/pluralize/westSlavic.ts
@@ -1,0 +1,15 @@
+import { I18n } from "../I18n";
+import { Pluralizer } from "../typing";
+
+export const westSlavic: Pluralizer = (_i18n: I18n, count: number) => {
+  const few = [2, 3, 4];
+  let key;
+  if (count == 1) {
+    key = "one";
+  } else if (few.includes(count)) {
+    key = "few";
+  } else {
+    key = "other";
+  }
+  return [key];
+};


### PR DESCRIPTION
<details>
  <summary>PR Checklist</summary>

### PR Structure

- [x] This PR has reasonably narrow scope (if not, break it down into smaller
      PRs).
- [x] This PR avoids mixing refactoring changes with feature changes (split into
      two PRs otherwise).
- [x] This PR's title starts is concise and descriptive.

### Thoroughness

- [x] This PR adds tests for the most critical parts of the new functionality or
      fixes.
- [x] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

Add pluralizer for west-slavic languages.

### Why

i18n-js is suppsed to work with rails, these pluralizers are present in rails-i18n

### Known limitations

N/A