### PR TITLE
Allow to override `interpolate` from outside the library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - [Added] `I18n#onChange` now returns a function that removes the handler from
   events.
+- [Added] `I18n#interpolate` is now available on the instance of `I18n` and can
+  therefore be overridden.
 
 # Jul 29, 2022
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,25 @@ const i18n = new I18n({
 i18n.t("greetings", { name: "John" });
 ```
 
+You may want to override the default [`interpolate`](https://github.com/fnando/i18n/blob/main/src/helpers/interpolate.ts) function with your own, if for instance you want these dynamic values to be React elements:
+
+```jsx
+const i18n = new I18n({
+  en: { greetings: "Hi, %{name}!" },
+  "pt-BR": { greetings: "Olá, %{name}!" },
+});
+
+i18n.interpolate = (i18n, message, options) => {
+  // ...
+}
+
+return (
+  <Text>
+    {i18n.t("greetings", { name: <BoldText>John</BoldText> })}
+  </Text>
+  )
+```
+
 #### Missing translations
 
 A translation may be missing. In that case, you may set the default value that's

--- a/src/I18n.ts
+++ b/src/I18n.ts
@@ -222,6 +222,7 @@ export class I18n {
     this.locales = new Locales(this);
     this.missingTranslation = new MissingTranslation(this);
     this.transformKey = transformKey;
+    this.interpolate = interpolate;
 
     this.store(translations);
   }
@@ -366,7 +367,7 @@ export class I18n {
     }
 
     if (typeof translation === "string") {
-      translation = interpolate(this, translation, options);
+      translation =this.interpolate(this, translation, options);
     } else if (
       typeof translation === "object" &&
       translation &&

--- a/src/I18n.ts
+++ b/src/I18n.ts
@@ -191,6 +191,13 @@ export class I18n {
    */
   public transformKey: (key: string) => string;
 
+  /**
+   * Override the interpolation function. For the default implementation, see
+   * [https://github.com/fnando/i18n/tree/main/src/helpers/interpolate.ts]
+   * @type {(i18n: I18n, message: string, options: TranslateOptions) => string}
+   */
+  public interpolate: typeof interpolate;
+
   constructor(translations: Dict = {}, options: Partial<I18nOptions> = {}) {
     const {
       locale,
@@ -367,7 +374,7 @@ export class I18n {
     }
 
     if (typeof translation === "string") {
-      translation =this.interpolate(this, translation, options);
+      translation = this.interpolate(this, translation, options);
     } else if (
       typeof translation === "object" &&
       translation &&

--- a/src/helpers/pluralize.ts
+++ b/src/helpers/pluralize.ts
@@ -1,7 +1,6 @@
 import { Scope, TranslateOptions } from "../typing";
 import { I18n } from "../I18n";
 
-import { interpolate } from "./interpolate";
 import { isSet } from "./isSet";
 import { lookup } from "./lookup";
 

--- a/src/helpers/pluralize.ts
+++ b/src/helpers/pluralize.ts
@@ -56,5 +56,5 @@ export function pluralize(
 
   options.count = count;
 
-  return interpolate(i18n, message, options);
+  return i18n.interpolate(i18n, message, options);
 }


### PR DESCRIPTION
<!--
If you're making a doc PR or something tiny where the below is irrelevant,
delete this template and use a short description, but in your description aim to
include both what the change is, and why it is being made, with enough context
for anyone to understand.
-->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [x] This PR has reasonably narrow scope (if not, break it down into smaller
      PRs).
- [x] This PR avoids mixing refactoring changes with feature changes (split into
      two PRs otherwise).
- [x] This PR's title starts is concise and descriptive.

### Thoroughness

- [x] This PR adds tests for the most critical parts of the new functionality or
      fixes.
- [x] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

Allows `i18n.interpolate` to be overridden from the outside.
Example use case: passing React elements as options to an interpolated string. To achieve that, one must override the `interpolate` function used internally by i18n-js.

### Why

As `interpolate` is being called at the moment, it makes it impossible for i18n-js users to override it.

### Known limitations

N/A
