### PR TITLE
Fixes circular dependency

### DIFF
--- a/src/helpers/createTranslationOptions.ts
+++ b/src/helpers/createTranslationOptions.ts
@@ -1,6 +1,6 @@
 import { Dict, Scope, TranslateOptions } from "../typing";
 import { I18n } from "../I18n";
-import { isSet } from ".";
+import { isSet } from "./isSet";
 
 /**
  * Generate a list of translation options for default fallback.

--- a/src/helpers/interpolate.ts
+++ b/src/helpers/interpolate.ts
@@ -1,6 +1,6 @@
 import { TranslateOptions } from "../typing";
 import { I18n } from "../I18n";
-import { isSet } from ".";
+import { isSet } from "./isSet";
 
 /**
  * This function interpolates the all variables in the given message.

--- a/src/helpers/lookup.ts
+++ b/src/helpers/lookup.ts
@@ -2,7 +2,9 @@ import { get } from "lodash";
 
 import { Dict, Scope } from "../typing";
 import { I18n } from "../I18n";
-import { isSet, getFullScope, inferType } from ".";
+import { isSet } from "./isSet";
+import { getFullScope } from "./getFullScope";
+import { inferType } from "./inferType";
 
 /**
  * Find and process the translation using the provided scope and options.

--- a/src/helpers/numberToHuman.ts
+++ b/src/helpers/numberToHuman.ts
@@ -3,7 +3,10 @@ import { sortBy, zipObject } from "lodash";
 
 import { I18n } from "../I18n";
 import { Numeric, NumberToHumanOptions, NumberToHumanUnits } from "../typing";
-import { getFullScope, lookup, roundNumber, inferType } from ".";
+import { getFullScope } from "./getFullScope";
+import { lookup } from "./lookup";
+import { roundNumber } from "./roundNumber";
+import { inferType } from "./inferType";
 
 /**
  * Set decimal units used to calculate number to human formatting.

--- a/src/helpers/numberToHumanSize.ts
+++ b/src/helpers/numberToHumanSize.ts
@@ -2,7 +2,8 @@ import BigNumber from "bignumber.js";
 
 import { I18n } from "../I18n";
 import { Numeric, NumberToHumanSizeOptions } from "../typing";
-import { roundNumber, expandRoundMode } from ".";
+import { roundNumber } from "./roundNumber";
+import { expandRoundMode } from "./expandRoundMode";
 
 /**
  * Set default size units.

--- a/src/helpers/pluralize.ts
+++ b/src/helpers/pluralize.ts
@@ -1,7 +1,9 @@
 import { Scope, TranslateOptions } from "../typing";
 import { I18n } from "../I18n";
 
-import { interpolate, isSet, lookup } from ".";
+import { interpolate } from "./interpolate";
+import { isSet } from "./isSet";
+import { lookup } from "./lookup";
 
 /**
  * Pluralize the given scope using the `count` value.

--- a/src/helpers/roundNumber.ts
+++ b/src/helpers/roundNumber.ts
@@ -1,7 +1,7 @@
 import BigNumber from "bignumber.js";
 
 import { RoundingMode } from "../typing";
-import { expandRoundMode } from ".";
+import { expandRoundMode } from "./expandRoundMode";
 
 type RoundingOptions = {
   roundMode: RoundingMode;

--- a/src/helpers/timeAgoInWords.ts
+++ b/src/helpers/timeAgoInWords.ts
@@ -2,7 +2,7 @@ import { range } from "lodash";
 
 import { I18n } from "../I18n";
 import { DateTime, TimeAgoInWordsOptions } from "../typing";
-import { parseDate } from ".";
+import { parseDate } from "./parseDate";
 
 const within = (start: number, end: number, actual: number): boolean =>
   actual >= start && actual <= end;


### PR DESCRIPTION
### What

This commit fixes a bug of circular dependencies.

### Why

Throws error on undefined isSet function when used with React Native /w TypeScript.

Relates to this issue: https://stackoverflow.com/questions/49116860/webpack-es6-modules-circular-dependencies-when-using-index-files
