### PR TITLE
add typing declares of `formatNumber` and `expandRoundMode`

### DIFF
--- a/typings/helpers/expandRoundMode.d.ts
+++ b/typings/helpers/expandRoundMode.d.ts
@@ -1,1 +1,6 @@
-export {};
+import BigNumber from "bignumber.js";
+import { RoundingMode } from "../typing";
+
+export declare function expandRoundMode(
+  roundMode: RoundingMode,
+): BigNumber.RoundingMode;

--- a/typings/helpers/formatNumber.d.ts
+++ b/typings/helpers/formatNumber.d.ts
@@ -1,1 +1,6 @@
-export {};
+import { FormatNumberOptions, Numeric } from "../typing";
+
+export declare function formatNumber(
+  input: Numeric,
+  options: FormatNumberOptions,
+): string;


### PR DESCRIPTION
<!--
If you're making a doc PR or something tiny where the below is irrelevant,
delete this template and use a short description, but in your description aim to
include both what the change is, and why it is being made, with enough context
for anyone to understand.
-->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [x] This PR has reasonably narrow scope (if not, break it down into smaller
      PRs).
- [x] This PR avoids mixing refactoring changes with feature changes (split into
      two PRs otherwise).
- [x] This PR's title starts is concise and descriptive.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or
      fixes.
- [ ] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

Add typing declares of `formatNumber` and `expandRoundMode`

### Why

After bumping v4.1.0, `tsc` says

```
> tsc -p tsconfig.json

Error: node_modules/i1[8](https://github.com/nota/GyazoRails/runs/8008902065?check_suite_focus=true#step:6:9)n-js/typings/helpers/index.d.ts(3,10): error TS2305: Module '"./expandRoundMode"' has no exported member 'expandRoundMode'.
Error: node_modules/i18n-js/typings/helpers/index.d.ts(4,10): error TS2305: Module '"./formatNumber"' has no exported member 'formatNumber'.
```

### Known limitations

[TODO or N/A]
