### PR TITLE
Interpolate strings when `i18n.t(..args)` returns an array.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Prefix your message with one of the following:
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+# Unreleased
+
+- [Changed] Interpolate strings when `i18n.t(..args)` returns an array.
+
 # v4.1.1 - Aug 25, 2022
 
 - [Changed] Removed `@internal` annotation from functions, so TypeScript can

--- a/README.md
+++ b/README.md
@@ -188,7 +188,22 @@ const i18n = new I18n({
 i18n.t("greetings", { name: "John" });
 ```
 
-You may want to override the default [`interpolate`](https://github.com/fnando/i18n/blob/main/src/helpers/interpolate.ts) function with your own, if for instance you want these dynamic values to be React elements:
+If the translation is an array and the entry is a string, values will be
+interpolated in a shallow way.
+
+```js
+const i18n = new I18n({
+  en: { messages: ["Hello there!", "Welcome back, %{name}!"] },
+});
+
+i18n.t("messages", { name: "John" });
+//=> ["Hello there!", "Welcome back, John!"]
+```
+
+You may want to override the default
+[`interpolate`](https://github.com/fnando/i18n/blob/main/src/helpers/interpolate.ts)
+function with your own, if for instance you want these dynamic values to be
+React elements:
 
 ```jsx
 const i18n = new I18n({
@@ -198,13 +213,9 @@ const i18n = new I18n({
 
 i18n.interpolate = (i18n, message, options) => {
   // ...
-}
+};
 
-return (
-  <Text>
-    {i18n.t("greetings", { name: <BoldText>John</BoldText> })}
-  </Text>
-  )
+return <Text>{i18n.t("greetings", { name: <BoldText>John</BoldText> })}</Text>;
 ```
 
 #### Missing translations

--- a/__tests__/interpolation.test.ts
+++ b/__tests__/interpolation.test.ts
@@ -54,3 +54,16 @@ test("provides missingPlaceholder with the placeholder, message, and options obj
   expect(message).toEqual("Hello {{name}}!");
   expect(options.debugScope).toEqual("landing-page");
 });
+
+test("interpolates array of strings", () => {
+  const i18n = new I18n({
+    en: {
+      someTranslation: ["Some text", "Value of something is {{value}}", 42],
+    },
+  });
+
+  const actual = i18n.t("someTranslation", { value: 123 });
+  const expected = ["Some text", "Value of something is 123", 42];
+
+  expect(actual).toEqual(expected);
+});

--- a/src/I18n.ts
+++ b/src/I18n.ts
@@ -387,6 +387,14 @@ export class I18n {
       );
     }
 
+    if (options && translation instanceof Array) {
+      translation = translation.map((entry) =>
+        typeof entry === "string"
+          ? interpolate(this, entry, options as TranslateOptions)
+          : entry,
+      );
+    }
+
     return translation as string;
   }
 


### PR DESCRIPTION
Close #28.

<!--
If you're making a doc PR or something tiny where the below is irrelevant,
delete this template and use a short description, but in your description aim to
include both what the change is, and why it is being made, with enough context
for anyone to understand.
-->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [x] This PR has reasonably narrow scope (if not, break it down into smaller
      PRs).
- [x] This PR avoids mixing refactoring changes with feature changes (split into
      two PRs otherwise).
- [x] This PR's title starts is concise and descriptive.

### Thoroughness

- [x] This PR adds tests for the most critical parts of the new functionality or
      fixes.
- [x] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

Interpolate strings when `i18n.t(..args)` returns an array. The requirement is that each item will only be interpolated when the value is a string.

### Why

To fix is a regression bug from v3 to v4.

### Known limitations

The interpolation is shallow (no nested arrays/objects is iterated).
