### PR TITLE
Import roundNumber directly to formatNumber.js fix require cycle issue

### DIFF
--- a/src/helpers/formatNumber.ts
+++ b/src/helpers/formatNumber.ts
@@ -2,7 +2,7 @@ import BigNumber from "bignumber.js";
 import { repeat } from "lodash";
 
 import { FormatNumberOptions, Numeric } from "../typing";
-import { roundNumber } from ".";
+import { roundNumber } from "./roundNumber";
 
 function replaceInFormat(
   format: string,


### PR DESCRIPTION

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [X] This PR has reasonably narrow scope (if not, break it down into smaller
      PRs).
- [X] This PR avoids mixing refactoring changes with feature changes (split into
      two PRs otherwise).
- [X] This PR's title starts is concise and descriptive.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or
      fixes.
- [ ] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

Updating the import for `roundNumber` in `formatNumber.ts` from  being imported from `index.ts` to being imported from `roundNumber.ts`

### Why

In my ReactNative project while in development mode I was seeing a require cycle warning which pointed to this library: 

The cycle:

1. `index.ts` imports `roundNumber` from `roundNumber.ts` 
2. `index.ts` imports  `formatNumber` from `formatNumber.ts` 
3. `formatNumber.ts` imports `roundNumber` from `index.ts` 

Since both `numberToHuman.ts` and `numberToHumanSize.ts` import `roundNumber` directly from `roundNumber.ts` instead of from `index.ts` like `formatNumber.ts` does it seemed to me that updating the import of  `roundNumber` in `formatNumber.ts` would be an overall improvement in terms of consistency as well as fix the require cycle.
