### PR TITLE
Change I18n#translate return type to be union with generics.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Prefix your message with one of the following:
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+# Unreleased
+
+- [Changed] The `I18n#translate`'s return type is now a string and generics
+  union.
+
 # v4.2.0 - Nov 24, 2022
 
 - [Changed] Interpolate strings when `i18n.t(..args)` returns an array.

--- a/src/I18n.ts
+++ b/src/I18n.ts
@@ -342,9 +342,12 @@ export class I18n {
    * returned will be either the first scope recognized, or the first message
    * defined.
    *
-   * @returns {string} The translated string.
+   * @returns {T | string} The translated string.
    */
-  public translate(scope: Scope, options?: TranslateOptions): string {
+  public translate<T = string>(
+    scope: Scope,
+    options?: TranslateOptions,
+  ): string | T {
     options = { ...options };
 
     const translationOptions: TranslateOptions[] = createTranslationOptions(
@@ -395,7 +398,7 @@ export class I18n {
       );
     }
 
-    return translation as string;
+    return translation as string | T;
   }
 
   /**


### PR DESCRIPTION
<!--
If you're making a doc PR or something tiny where the below is irrelevant,
delete this template and use a short description, but in your description aim to
include both what the change is, and why it is being made, with enough context
for anyone to understand.
-->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller
      PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into
      two PRs otherwise).
- [ ] This PR's title starts is concise and descriptive.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or
      fixes.
- [ ] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

Change `I18n#translate`'s return to be a string and generics union.

### Why

Close #29 

### Known limitations

N/A