### PR TITLE
Reduce the size impact of lodash by picking the required modules only

### DIFF
--- a/src/I18n.ts
+++ b/src/I18n.ts
@@ -1,6 +1,8 @@
 /* eslint-disable class-methods-use-this, no-underscore-dangle */
 
-import { get, has, set } from "lodash";
+import get from "lodash/get";
+import has from "lodash/has";
+import set from "lodash/set";
 
 import {
   DateTime,

--- a/src/Locales.ts
+++ b/src/Locales.ts
@@ -1,4 +1,4 @@
-import { uniq } from "lodash";
+import uniq from "lodash/uniq";
 
 import { Dict, LocaleResolver } from "./typing";
 import { I18n } from "./I18n";

--- a/src/helpers/camelCaseKeys.ts
+++ b/src/helpers/camelCaseKeys.ts
@@ -1,4 +1,4 @@
-import { camelCase } from "lodash";
+import camelCase from "lodash/camelCase";
 
 import { Dict } from "../typing";
 

--- a/src/helpers/formatNumber.ts
+++ b/src/helpers/formatNumber.ts
@@ -1,5 +1,5 @@
 import BigNumber from "bignumber.js";
-import { repeat } from "lodash";
+import repeat from "lodash/repeat";
 
 import { FormatNumberOptions, Numeric } from "../typing";
 import { roundNumber } from "./roundNumber";

--- a/src/helpers/lookup.ts
+++ b/src/helpers/lookup.ts
@@ -1,4 +1,4 @@
-import { get } from "lodash";
+import get from "lodash/get";
 
 import { Dict, Scope } from "../typing";
 import { I18n } from "../I18n";

--- a/src/helpers/numberToHuman.ts
+++ b/src/helpers/numberToHuman.ts
@@ -1,5 +1,6 @@
 import BigNumber from "bignumber.js";
-import { sortBy, zipObject } from "lodash";
+import sortBy from "lodash/sortBy";
+import zipObject from "lodash/zipObject";
 
 import { I18n } from "../I18n";
 import { Numeric, NumberToHumanOptions, NumberToHumanUnits } from "../typing";

--- a/src/helpers/propertyFlatList.ts
+++ b/src/helpers/propertyFlatList.ts
@@ -1,4 +1,7 @@
-import { isArray, isObject, flattenDeep } from "lodash";
+import isArray from "lodash/isArray";
+import isObject from "lodash/isObject";
+import flattenDeep from "lodash/flattenDeep";
+
 import { Dict } from "../typing";
 
 interface Indexable {

--- a/src/helpers/timeAgoInWords.ts
+++ b/src/helpers/timeAgoInWords.ts
@@ -1,4 +1,4 @@
-import { range } from "lodash";
+import range from "lodash/range";
 
 import { I18n } from "../I18n";
 import { DateTime, TimeAgoInWordsOptions } from "../typing";


### PR DESCRIPTION
<details>
  <summary>PR Checklist</summary>

### PR Structure

- [x] This PR has reasonably narrow scope (if not, break it down into smaller
      PRs).
- [x] This PR avoids mixing refactoring changes with feature changes (split into
      two PRs otherwise).
- [x] This PR's title starts is concise and descriptive.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or
      fixes.
- [ ] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

Change `import { module } form "lodash"` lines to `import module from "lodash/module"` to reduce the size of the bundle.

### Why

Currently the code bings the whole lodash module to the final browser bundle which ends up being bigger than it should be. If you import only the required packages, you can reduce the size of the final bundle.

Steps to reproduce:

```bash
yarn build:import
yarn build:browser
ls -lah dist/browser
```

On the main branch it generates a 105K file for `index.js`, with this fix the file is only 67K

### Known limitations

N/A
