### PR TITLE
Add wrapper that creates pluralizers for make-plural functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Prefix your message with one of the following:
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+# Unreleased
+
+- [Added] Introduce `useMakePlural(options)` function as way of creating
+  pluralizers on top of [make-plural](https://github.com/eemeli/make-plural/).
+- [Changed] Use `make-plural`'s `en` function as the default pluralizer.
+
 # V4.2.2 - Dec 16, 2022
 
 - [Changed] Import lodash modules directly, which reduces final exported size by

--- a/README.md
+++ b/README.md
@@ -409,9 +409,17 @@ i18n.pluralization.register("ru", (_i18n, count) => {
 You can find all rules on
 [http://www.unicode.org/](http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html).
 
-It's encourage to publish your pluralizers using the following name pattern:
-`i18n-<locale>-pluralizer`. If you publish a pluralizer, please add a pull
-request so we can list it here.
+You can also leverage [make-plural](https://github.com/eemeli/make-plural/),
+rather than writing all your pluralization functions. For this, you must wrap
+make-plural's function by using
+`useMakePlural({ pluralizer, includeZero, ordinal })`:
+
+```js
+import { ru } from "make-plural";
+import { useMakePlural } from "i18n-js";
+
+i18n.pluralization.register("ru", useMakePlural({ pluralizer: ru }));
+```
 
 #### Other options
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "bignumber.js": "*",
-    "lodash": "*"
+    "lodash": "*",
+    "make-plural": "*"
   }
 }

--- a/src/I18n.ts
+++ b/src/I18n.ts
@@ -49,6 +49,7 @@ import {
 
 const DEFAULT_I18N_OPTIONS: I18nOptions = {
   defaultLocale: "en",
+  availableLocales: ["en"],
   locale: "en",
   defaultSeparator: ".",
   placeholder: /(?:\{\{|%\{)(.*?)(?:\}\}?)/gm,
@@ -200,6 +201,13 @@ export class I18n {
    * @type {(i18n: I18n, message: string, options: TranslateOptions) => string}
    */
   public interpolate: typeof interpolate;
+
+  /**
+   * Set the available locales.
+   *
+   * @type {string[]}
+   */
+  public availableLocales: string[] = [];
 
   constructor(translations: Dict = {}, options: Partial<I18nOptions> = {}) {
     const {

--- a/src/Pluralization.ts
+++ b/src/Pluralization.ts
@@ -1,5 +1,35 @@
-import { Dict, Pluralizer } from "./typing";
+import { en } from "make-plural";
+
+import { Dict, Pluralizer, MakePlural } from "./typing";
 import { I18n } from "./I18n";
+
+/**
+ * Creates a new pluralizer function based on [make-plural](https://github.com/eemeli/make-plural/tree/master/packages/plurals).
+ *
+ * @param  {boolean} options.includeZero When `true`, will return `zero` as the
+ *                                       first key for `0` pluralization.
+ * @param  {boolean} options.ordinal When `true`, will return the scope based on
+ *                                   make-plural's ordinal category.
+ * @param {MakePlural} options.pluralizer The make-plural function that will be
+ *                                        wrapped.
+ * @return {Pluralizer}    [description]
+ */
+export function useMakePlural({
+  pluralizer,
+  includeZero = true,
+  ordinal = false,
+}: {
+  pluralizer: MakePlural;
+  includeZero?: boolean;
+  ordinal?: boolean;
+}): Pluralizer {
+  return function (_i18n: I18n, count: number) {
+    return [
+      includeZero && count === 0 ? "zero" : "",
+      pluralizer(count, ordinal),
+    ].filter(Boolean);
+  };
+}
 
 /**
  * The default pluralizer.
@@ -20,19 +50,10 @@ import { I18n } from "./I18n";
  *
  * @returns {string[]} The list of possible translation scopes.
  */
-export const defaultPluralizer: Pluralizer = (
-  _i18n: I18n,
-  count: number,
-): string[] => {
-  switch (count) {
-    case 0:
-      return ["zero", "other"];
-    case 1:
-      return ["one"];
-    default:
-      return ["other"];
-  }
-};
+export const defaultPluralizer: Pluralizer = useMakePlural({
+  pluralizer: en,
+  includeZero: true,
+});
 
 /**
  * This class enables registering different strategies for pluralization, as

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { I18n } from "./I18n";
 export { Locales } from "./Locales";
 export { MissingTranslation } from "./MissingTranslation";
-export { Pluralization } from "./Pluralization";
+export { Pluralization, useMakePlural } from "./Pluralization";
 export * from "./typing";

--- a/src/typing.ts
+++ b/src/typing.ts
@@ -2,6 +2,8 @@ import BigNumber from "bignumber.js";
 
 import { I18n } from "./I18n";
 
+export type MakePlural = (count: number, ordinal?: boolean) => string;
+
 export interface Dict {
   [key: string]: any;
 }
@@ -120,6 +122,13 @@ export interface I18nOptions {
    * @type {string}
    */
   defaultLocale: string;
+
+  /**
+   * Set available locales. This will be used to load pluralizers automatically.
+   *
+   * @type {string[]}
+   */
+  availableLocales: string[];
 
   /**
    * Set the default string separator. Defaults to `.`, as in


### PR DESCRIPTION
<!--
If you're making a doc PR or something tiny where the below is irrelevant,
delete this template and use a short description, but in your description aim to
include both what the change is, and why it is being made, with enough context
for anyone to understand.
-->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [x] This PR has reasonably narrow scope (if not, break it down into smaller
      PRs).
- [x] This PR avoids mixing refactoring changes with feature changes (split into
      two PRs otherwise).
- [x] This PR's title starts is concise and descriptive.

### Thoroughness

- [x] This PR adds tests for the most critical parts of the new functionality or
      fixes.
- [x] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

Add support for [make-plural](https://github.com/eemeli/make-plural/) pluralizers with a new abstraction function called `useMakePlural(options)`.

### Why

To support more pluralization rules for different languages. Close #22.

### Known limitations

The pluralization activation is not automatic and requires configuration. We may explore automatic activation in the future.
