### PR TITLE
fix(lookup): fixed keys with dots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.log
 *.tgz
 /coverage
+/node_modules

--- a/__tests__/fixtures/translations.ts
+++ b/__tests__/fixtures/translations.ts
@@ -11,6 +11,7 @@ export function translations(): { [key: string]: any } {
     },
     greetings: {
       stranger: "Hello stranger!",
+      "stranger.dot": "Hello stranger.dot!",
       name: "Hello {{name}}!",
     },
     profile: {

--- a/__tests__/translate.test.ts
+++ b/__tests__/translate.test.ts
@@ -168,6 +168,13 @@ test("returns translation for custom scope separator", () => {
   expect(actual).toEqual("Hello stranger!");
 });
 
+test("returns translation for custom scope separator and dots", () => {
+  i18n.defaultSeparator = "•";
+  const actual = i18n.t("greetings•stranger.dot");
+
+  expect(actual).toEqual("Hello stranger.dot!");
+});
+
 test("returns boolean values", () => {
   expect(i18n.t("booleans.yes")).toBeTruthy();
   expect(i18n.t("booleans.no")).toBeFalsy();

--- a/src/I18n.ts
+++ b/src/I18n.ts
@@ -3,6 +3,7 @@
 import get from "lodash/get";
 import has from "lodash/has";
 import set from "lodash/set";
+import merge from "lodash/merge";
 
 import {
   DateTime,
@@ -42,7 +43,6 @@ import {
   numberToHumanSize,
   parseDate,
   pluralize,
-  propertyFlatList,
   strftime,
   timeAgoInWords,
 } from "./helpers";
@@ -255,12 +255,7 @@ export class I18n {
    * @returns {void}
    */
   public store(translations: Dict): void {
-    const map = propertyFlatList(translations);
-
-    map.forEach((path) =>
-      set(this.translations, path, get(translations, path)),
-    );
-
+    merge(this.translations, translations);
     this.hasChanged();
   }
 

--- a/src/helpers/lookup.ts
+++ b/src/helpers/lookup.ts
@@ -1,5 +1,3 @@
-import get from "lodash/get";
-
 import { Dict, Scope } from "../typing";
 import { I18n } from "../I18n";
 import { isSet } from "./isSet";
@@ -31,13 +29,12 @@ export function lookup(i18n: I18n, scope: Scope, options: Dict = {}): any {
     .get(localeType === "string" ? locale : typeof locale)
     .slice();
 
-  scope = getFullScope(i18n, scope, options)
+  const keys = getFullScope(i18n, scope, options)
     .split(i18n.defaultSeparator)
-    .map((component) => i18n.transformKey(component))
-    .join(".");
+    .map((component) => i18n.transformKey(component));
 
   const entries = locales.map((locale) =>
-    get(i18n.translations, [locale, scope].join(".")),
+    keys.reduce((path, key) => path && path[key], i18n.translations[locale]),
   );
 
   entries.push(options.defaultValue);


### PR DESCRIPTION
<!--
If you're making a doc PR or something tiny where the below is irrelevant,
delete this template and use a short description, but in your description aim to
include both what the change is, and why it is being made, with enough context
for anyone to understand.
-->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [x] This PR has reasonably narrow scope (if not, break it down into smaller
      PRs).
- [x] This PR avoids mixing refactoring changes with feature changes (split into
      two PRs otherwise).
- [x] This PR's title starts is concise and descriptive.

### Thoroughness

- [x] This PR adds tests for the most critical parts of the new functionality or
      fixes.
- [x] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

Added support for the character '.' in the translation key

### Why

Some translation keys can accurately reflect the translated English sentence, for example: 'Only available for Desktop. On the Mobile App, the display ecc...', so support for all punctuation characters is needed

The [3.9.2](https://www.npmjs.com/package/i18n-js/v/3.9.2) version worked fine with dots.

### Info

The lodash 'get' function splits by char '.' and looks for the keys, like `dictionary[splitKey[0]][splitKey[1]][...];`
```js
// doesn't support this:
{
    "standard": {
        "Only available for Desktop. On the Mobile App, the display etc...": "translation",
    }
}
```` 

The problem is when a key contains a '.' because the lodash 'get' function interprets it not as part of the key but as a separator.
So, the solution is to use a reduce function to iterate through all the keys in the path generated by:
https://github.com/fnando/i18n/blob/d4a14ca41d815403ee331f0e63d9b41aa612cbbc/src/helpers/lookup.ts#L34-L36
