### PR TITLE
Use Array.isArray

### DIFF
--- a/src/helpers/propertyFlatList.ts
+++ b/src/helpers/propertyFlatList.ts
@@ -1,4 +1,3 @@
-import isArray from "lodash/isArray";
 import isObject from "lodash/isObject";
 import flattenDeep from "lodash/flattenDeep";
 
@@ -28,7 +27,7 @@ class PropertyFlatList {
   }
 
   compute(value: unknown, path: string): unknown {
-    if (!isArray(value) && isObject(value)) {
+    if (!Array.isArray(value) && isObject(value)) {
       return Object.keys(value).map((key) =>
         this.compute((value as Indexable)[key] as unknown, `${path}.${key}`),
       );

--- a/src/lodash.ts
+++ b/src/lodash.ts
@@ -3,7 +3,6 @@ export { default as camelCase } from "lodash/camelCase";
 export { default as repeat } from "lodash/repeat";
 export { default as sortBy } from "lodash/sortBy";
 export { default as zipObject } from "lodash/zipObject";
-export { default as isArray } from "lodash/isArray";
 export { default as isObject } from "lodash/isObject";
 export { default as flattenDeep } from "lodash/flattenDeep";
 export { default as get } from "lodash/get";

--- a/typings/lodash.d.ts
+++ b/typings/lodash.d.ts
@@ -3,7 +3,6 @@ export { default as camelCase } from "lodash/camelCase";
 export { default as repeat } from "lodash/repeat";
 export { default as sortBy } from "lodash/sortBy";
 export { default as zipObject } from "lodash/zipObject";
-export { default as isArray } from "lodash/isArray";
 export { default as isObject } from "lodash/isObject";
 export { default as flattenDeep } from "lodash/flattenDeep";
 export { default as get } from "lodash/get";


### PR DESCRIPTION
`_.isArray` individual package has been deprecated, and in lodash it is just an alias of `Array.isArray`

This commit directly uses `Array.isArray` to avoid an import from lodash

Ref: https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11286

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [x] This PR has reasonably narrow scope (if not, break it down into smaller
      PRs).
- [x] This PR avoids mixing refactoring changes with feature changes (split into
      two PRs otherwise).
- [x] This PR's title starts is concise and descriptive.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or
      fixes.
- [ ] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

Use `Array.isArray` instead of `_.isArray`

### Why

`_.isArray` is an alias of `Array.isArray`, but the former will import a file from lodash

### Known limitations

Couldn't test on my local environment because of #69 
