### PR TITLE
Use lodash's setWith so it always use an object as the namespace.

### DIFF
--- a/__tests__/store.test.ts
+++ b/__tests__/store.test.ts
@@ -13,4 +13,16 @@ describe("I18n#store", () => {
     expect(get(i18n.translations, "pt.bye")).toEqual("Até logo");
     expect(get(i18n.translations, "en.colors.blue")).toEqual(["light", "dark"]);
   });
+
+  it("works with numeric keys", () => {
+    const i18n = new I18n();
+    i18n.store({ en: { units: { l: "liter", "1": "number" } } });
+
+    expect(get(i18n.translations, "en.units.l")).toEqual("liter");
+    expect(get(i18n.translations, "en.units.1")).toEqual("number");
+    expect(get(i18n.translations, "en.units")).toEqual({
+      l: "liter",
+      "1": "number",
+    });
+  });
 });

--- a/src/I18n.ts
+++ b/src/I18n.ts
@@ -3,6 +3,7 @@
 import get from "lodash/get";
 import has from "lodash/has";
 import set from "lodash/set";
+import setWith from "lodash/setWith";
 
 import {
   DateTime,
@@ -258,7 +259,7 @@ export class I18n {
     const map = propertyFlatList(translations);
 
     map.forEach((path) =>
-      set(this.translations, path, get(translations, path)),
+      setWith(this.translations, path, get(translations, path), Object),
     );
 
     this.hasChanged();

--- a/src/lodash.ts
+++ b/src/lodash.ts
@@ -10,3 +10,4 @@ export { default as flattenDeep } from "lodash/flattenDeep";
 export { default as get } from "lodash/get";
 export { default as has } from "lodash/has";
 export { default as set } from "lodash/set";
+export { default as setWith } from "lodash/setWith";


### PR DESCRIPTION
Close #72.

<!--
If you're making a doc PR or something tiny where the below is irrelevant,
delete this template and use a short description, but in your description aim to
include both what the change is, and why it is being made, with enough context
for anyone to understand.
-->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [x] This PR has reasonably narrow scope (if not, break it down into smaller
      PRs).
- [x] This PR avoids mixing refactoring changes with feature changes (split into
      two PRs otherwise).
- [x] This PR's title starts is concise and descriptive.

### Thoroughness

- [x] This PR adds tests for the most critical parts of the new functionality or
      fixes.
- [x] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

Uses lodash's `setWith` to store translations, so we can force the namespace to always be an object. Numeric keys are treated by `set` as an array if they come first in the list.

### Why

So we can have numeric keys working properly.

### Known limitations

N/A
