### PR TITLE
Use Array.isArray instead.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - [Fix] Storing translations that contain numeric keys now work properly;
   previously it was creating arrays instead of objects.
+- [Changed] Stop using lodash's `isArray` in favor of `Array.isArray`.
 
 ## v.3.1-beta.1 - Aug 26, 2023
 

--- a/src/helpers/propertyFlatList.ts
+++ b/src/helpers/propertyFlatList.ts
@@ -1,4 +1,3 @@
-import isArray from "lodash/isArray";
 import isObject from "lodash/isObject";
 import flattenDeep from "lodash/flattenDeep";
 
@@ -28,7 +27,7 @@ class PropertyFlatList {
   }
 
   compute(value: unknown, path: string): unknown {
-    if (!isArray(value) && isObject(value)) {
+    if (!Array.isArray(value) && isObject(value)) {
       return Object.keys(value).map((key) =>
         this.compute((value as Indexable)[key] as unknown, `${path}.${key}`),
       );

--- a/src/lodash.ts
+++ b/src/lodash.ts
@@ -4,7 +4,6 @@ export { default as snakeCase } from "lodash/snakeCase";
 export { default as repeat } from "lodash/repeat";
 export { default as sortBy } from "lodash/sortBy";
 export { default as zipObject } from "lodash/zipObject";
-export { default as isArray } from "lodash/isArray";
 export { default as isObject } from "lodash/isObject";
 export { default as flattenDeep } from "lodash/flattenDeep";
 export { default as get } from "lodash/get";


### PR DESCRIPTION
`_.isArray` individual package has been deprecated, and in lodash it is just an alias of `Array.isArray`.

This commit directly uses `Array.isArray` to avoid an import from lodash.

Ref: https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11286

Close #70 