### PR TITLE
Possible fix for #77 (CWE-185)

### DIFF
--- a/src/helpers/interpolate.ts
+++ b/src/helpers/interpolate.ts
@@ -44,9 +44,8 @@ export function interpolate(
       value = i18n.missingPlaceholder(i18n, placeholder, message, options);
     }
 
-    const regex = new RegExp(
-      placeholder.replace(/\{/gm, "\\{").replace(/\}/gm, "\\}"),
-    );
+    const escapedPlaceholder = placeholder.replace(/\{/gm, "\\{").replace(/\}/gm, "\\}");
+    const regex = new RegExp(escapedPlaceholder);
 
     message = message.replace(regex, value);
   }


### PR DESCRIPTION
https://github.com/fnando/i18n/blob/27e14e7b7f25150261b4d05b27d4ea1ca83256b7/src/helpers/interpolate.ts#L47-L49

Incorrect Regular Expression Severity: Medium
RegExp() called with a variable, this might allow an attacker to DOS your application with a long-running regular expression.

Possible improvement:

```
    const escapedPlaceholder = placeholder.replace(/\{/gm, "\\{").replace(/\}/gm, "\\}");
    const regex = new RegExp(escapedPlaceholder);
```
Fixes #77 
@fnando if the PR is desired please merge.

Best,

Khalil