### PR TITLE
fix: correct main, module, and browser package.json entrypoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "browser": "./dist/browser/index.js",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
+      "require": "./dist/require/index.js",
       "import": "./dist/import/index.js",
       "types": "./typings",
       "browser": "./dist/browser/index.js"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "src/**/*"
   ],
   "license": "MIT",
-  "main": "./dist/import/index.js",
+  "main": "./dist/require/index.js",
+  "module": "./dist/import/index.js",
+  "browser": "./dist/browser/index.js",
   "name": "i18n-js",
   "repository": "https://github.com/fnando/i18n",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,14 @@
   "main": "./dist/require/index.js",
   "module": "./dist/import/index.js",
   "browser": "./dist/browser/index.js",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/import/index.js",
+      "types": "./typings",
+      "browser": "./dist/browser/index.js"
+    }
+  },
   "name": "i18n-js",
   "repository": "https://github.com/fnando/i18n",
   "scripts": {


### PR DESCRIPTION
<details>
  <summary>PR Checklist</summary>

### PR Structure

- [x] This PR has reasonably narrow scope (if not, break it down into smaller
      PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into
      two PRs otherwise).
- [x] This PR's title starts is concise and descriptive.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or
      fixes.
- [ ] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

This PR updates the package.json to provide the correct entry points for the CJS, ESM, and browser files.

### Why

When using with Jest, it throws a bundling error because it looks at the "main" field and tries to load the ESM bundle instead of CJS error. 

"main": should be CJS https://docs.npmjs.com/cli/v10/configuring-npm/package-json#main
"module": should be ESM https://stackoverflow.com/questions/42708484/what-is-the-module-package-json-field-for
"browser": should be browser entry point https://docs.npmjs.com/cli/v10/configuring-npm/package-json#browser
"exports": see https://nodejs.org/api/packages.html#conditional-exports

### Known limitations

N/A