### PR TITLE
Add support for interpolating multiple instances of the same variable

### DIFF
--- a/__tests__/fixtures/translations.ts
+++ b/__tests__/fixtures/translations.ts
@@ -49,6 +49,8 @@ export function translations(): { [key: string]: any } {
         },
       },
     },
+
+    multiple_variables: "Hello, {{name}}! Your name is {{name}}.",
   };
 
   Translations["en-US"] = {

--- a/__tests__/interpolation.test.ts
+++ b/__tests__/interpolation.test.ts
@@ -15,6 +15,13 @@ test("performs multiple interpolations", () => {
   expect(actual).toEqual("John Doe is 27-years old");
 });
 
+test("interpolates multiple instances of each variable", () => {
+  const i18n = new I18n(translations());
+  const actual = i18n.t("multiple_variables", { name: "John Doe" });
+
+  expect(actual).toEqual("Hello, John Doe! Your name is John Doe.");
+});
+
 test("outputs missing placeholder message if interpolation value is missing", () => {
   const i18n = new I18n(translations());
   const actual = i18n.t("greetings.name");

--- a/src/helpers/interpolate.ts
+++ b/src/helpers/interpolate.ts
@@ -46,9 +46,10 @@ export function interpolate(
 
     const regex = new RegExp(
       placeholder.replace(/\{/gm, "\\{").replace(/\}/gm, "\\}"),
+      "g",
     );
 
-    message = message.replace(regex, value);
+    message = message.replaceAll(regex, value);
   }
 
   return message.replace(/_#\$#_/g, "$");


### PR DESCRIPTION
<!--
If you're making a doc PR or something tiny where the below is irrelevant,
delete this template and use a short description, but in your description aim to
include both what the change is, and why it is being made, with enough context
for anyone to understand.
-->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [x] This PR has reasonably narrow scope (if not, break it down into smaller
      PRs).
- [x] This PR avoids mixing refactoring changes with feature changes (split into
      two PRs otherwise).
- [x] This PR's title starts is concise and descriptive.

### Thoroughness

- [x] This PR adds tests for the most critical parts of the new functionality or
      fixes.
- [ ] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

Adds support for interpolating multiple instances of the same variable. For example:

```
You have {{totalCount}} new messages ({{urgentCount}} out of {{totalCount}} are urgent)
```

### Why

Without this, it's impossible to re-use the same variable value more than once within a string.

### Known limitations

N/A
