### PR TITLE
Fix numberToCurrency crash with bignumber.js v10 bundle

### DIFF
--- a/__tests__/bigNumberResolver.test.ts
+++ b/__tests__/bigNumberResolver.test.ts
@@ -1,0 +1,54 @@
+/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
+// `require` is used deliberately so each case can load the resolver after the
+// module mock is installed, reproducing how a bundler resolves bignumber.js.
+import RealBigNumber from "bignumber.js";
+
+// Regression coverage for https://github.com/fnando/i18n/issues/126
+//
+// bignumber.js v10 ships a "browser" bundle (an IIFE) that bundlers such as
+// Metro, Webpack and Parcel resolve via the package's "browser" field. That
+// bundle assigns the constructor to `globalThis.BigNumber` instead of exporting
+// it, so `require("bignumber.js")` yields an empty object and calling it throws
+// a TypeError. We simulate that by mocking the module with `{}` while exposing
+// the real constructor on the global, exactly as the IIFE does at runtime.
+
+describe("bigNumberResolver", () => {
+  const originalGlobal = (globalThis as { BigNumber?: unknown }).BigNumber;
+
+  afterEach(() => {
+    jest.dontMock("bignumber.js");
+    jest.resetModules();
+    (globalThis as { BigNumber?: unknown }).BigNumber = originalGlobal;
+  });
+
+  test("uses the module export when it is callable", () => {
+    const resolved = require("../src/helpers/bigNumberResolver").default;
+
+    expect(typeof resolved).toBe("function");
+    expect(new resolved(1500).toNumber()).toBe(1500);
+  });
+
+  test("falls back to globalThis.BigNumber when the browser bundle leaves the export empty", () => {
+    jest.isolateModules(() => {
+      jest.doMock("bignumber.js", () => ({}));
+      (globalThis as { BigNumber?: unknown }).BigNumber = RealBigNumber;
+
+      const resolved = require("../src/helpers/bigNumberResolver").default;
+
+      expect(resolved).toBe(RealBigNumber);
+      expect(new resolved(1500).toNumber()).toBe(1500);
+    });
+  });
+
+  test("numberToCurrency works under the broken browser bundle", () => {
+    jest.isolateModules(() => {
+      jest.doMock("bignumber.js", () => ({}));
+      (globalThis as { BigNumber?: unknown }).BigNumber = RealBigNumber;
+
+      const { I18n } = require("../src/I18n");
+      const i18n = new I18n();
+
+      expect(i18n.numberToCurrency(1500)).toEqual("$1,500.00");
+    });
+  });
+});

--- a/src/helpers/bigNumberResolver.ts
+++ b/src/helpers/bigNumberResolver.ts
@@ -1,0 +1,22 @@
+import BigNumber from "bignumber.js";
+
+/**
+ * bignumber.js v10 added a "browser" field to its package.json that points at
+ * an IIFE build. Bundlers that honor the "browser" field (Metro/React Native,
+ * Webpack, Parcel) load that build, but it assigns the constructor to
+ * `globalThis.BigNumber` instead of exporting it through CommonJS/ESM. As a
+ * result the default import resolves to an empty object and calling it throws a
+ * TypeError (e.g. from `numberToCurrency`). Plain Node.js is unaffected because
+ * it resolves the "main" field, which still exports the constructor.
+ *
+ * Resolve the constructor defensively: use the imported value when it is
+ * callable, otherwise fall back to the global the IIFE installed.
+ *
+ * See https://github.com/fnando/i18n/issues/126
+ */
+const resolvedBigNumber: typeof BigNumber =
+  typeof BigNumber === "function"
+    ? BigNumber
+    : (globalThis as unknown as { BigNumber: typeof BigNumber }).BigNumber;
+
+export default resolvedBigNumber;

--- a/src/helpers/expandRoundMode.ts
+++ b/src/helpers/expandRoundMode.ts
@@ -1,5 +1,7 @@
-import BigNumber from "bignumber.js";
+import type BigNumberType from "bignumber.js";
+
 import { RoundingMode } from "../typing";
+import BigNumber from "./bigNumberResolver";
 
 enum RoundingModeMap {
   "up" = BigNumber.ROUND_UP,
@@ -22,7 +24,7 @@ enum RoundingModeMap {
  */
 export function expandRoundMode(
   roundMode: RoundingMode,
-): BigNumber.RoundingMode {
+): BigNumberType.RoundingMode {
   return (RoundingModeMap[roundMode] ??
-    RoundingModeMap.default) as BigNumber.RoundingMode;
+    RoundingModeMap.default) as BigNumberType.RoundingMode;
 }

--- a/src/helpers/formatNumber.ts
+++ b/src/helpers/formatNumber.ts
@@ -1,9 +1,9 @@
-import BigNumber from "bignumber.js";
 import repeat from "lodash/repeat";
 
 import { FormatNumberOptions, Numeric } from "../typing";
 import { roundNumber } from "./roundNumber";
 import { parseBigNumber } from "./parseBigNumber";
+import BigNumber from "./bigNumberResolver";
 
 function replaceInFormat(
   format: string,

--- a/src/helpers/numberToHuman.ts
+++ b/src/helpers/numberToHuman.ts
@@ -1,4 +1,4 @@
-import BigNumber from "bignumber.js";
+import type BigNumberType from "bignumber.js";
 import sortBy from "lodash/sortBy";
 import zipObject from "lodash/zipObject";
 
@@ -9,6 +9,7 @@ import { lookup } from "./lookup";
 import { roundNumber } from "./roundNumber";
 import { inferType } from "./inferType";
 import { parseBigNumber } from "./parseBigNumber";
+import BigNumber from "./bigNumberResolver";
 
 /**
  * Set decimal units used to calculate number to human formatting.
@@ -91,7 +92,7 @@ export function numberToHuman(
       (numeric) => numeric * -1,
     );
 
-  const calculateExponent = (num: BigNumber, units: NumberToHumanUnits) => {
+  const calculateExponent = (num: BigNumberType, units: NumberToHumanUnits) => {
     const exponent = num.isZero()
       ? 0
       : Math.floor(Math.log10(num.abs().toNumber()));

--- a/src/helpers/numberToHumanSize.ts
+++ b/src/helpers/numberToHumanSize.ts
@@ -1,10 +1,11 @@
-import BigNumber from "bignumber.js";
+import type BigNumberType from "bignumber.js";
 
 import { I18n } from "../I18n";
 import { Numeric, NumberToHumanSizeOptions } from "../typing";
 import { roundNumber } from "./roundNumber";
 import { expandRoundMode } from "./expandRoundMode";
 import { parseBigNumber } from "./parseBigNumber";
+import BigNumber from "./bigNumberResolver";
 
 /**
  * Set default size units.
@@ -33,7 +34,7 @@ export function numberToHumanSize(
   const smallerThanBase = num.lt(base);
   let numberToBeFormatted;
 
-  const computeExponent = (numeric: BigNumber, units: string[]) => {
+  const computeExponent = (numeric: BigNumberType, units: string[]) => {
     const max = units.length - 1;
     const exp = new BigNumber(Math.log(numeric.toNumber()))
       .div(Math.log(base))

--- a/src/helpers/parseBigNumber.ts
+++ b/src/helpers/parseBigNumber.ts
@@ -1,5 +1,5 @@
-import BigNumber from "bignumber.js";
 import { Numeric } from "typing";
+import BigNumber from "./bigNumberResolver";
 
 export function parseBigNumber(input: Numeric, raise: boolean = false) {
   let output = BigNumber(NaN);

--- a/src/helpers/roundNumber.ts
+++ b/src/helpers/roundNumber.ts
@@ -1,7 +1,8 @@
-import BigNumber from "bignumber.js";
+import type BigNumberType from "bignumber.js";
 
 import { RoundingMode } from "../typing";
 import { expandRoundMode } from "./expandRoundMode";
+import BigNumber from "./bigNumberResolver";
 
 type RoundingOptions = {
   roundMode: RoundingMode;
@@ -9,7 +10,7 @@ type RoundingOptions = {
   significant: boolean;
 };
 
-function digitCount(numeric: BigNumber): number {
+function digitCount(numeric: BigNumberType): number {
   if (numeric.isZero()) {
     return 1;
   }
@@ -18,7 +19,7 @@ function digitCount(numeric: BigNumber): number {
 }
 
 function getAbsolutePrecision(
-  numeric: BigNumber,
+  numeric: BigNumberType,
   { precision, significant }: RoundingOptions,
 ): number | null {
   if (significant && precision !== null && precision > 0) {
@@ -40,7 +41,7 @@ function getAbsolutePrecision(
  * @return {string} The rounded number.
  */
 export function roundNumber(
-  numeric: BigNumber,
+  numeric: BigNumberType,
   options: RoundingOptions,
 ): string {
   const precision = getAbsolutePrecision(numeric, options);

--- a/src/typing.ts
+++ b/src/typing.ts
@@ -1,4 +1,4 @@
-import BigNumber from "bignumber.js";
+import type BigNumber from "bignumber.js";
 import { I18n } from "./I18n";
 
 export type MakePlural = (count: number, ordinal?: boolean) => string;

--- a/typings/helpers/bigNumberResolver.d.ts
+++ b/typings/helpers/bigNumberResolver.d.ts
@@ -1,0 +1,3 @@
+import BigNumber from "bignumber.js";
+declare const resolvedBigNumber: typeof BigNumber;
+export default resolvedBigNumber;

--- a/typings/helpers/expandRoundMode.d.ts
+++ b/typings/helpers/expandRoundMode.d.ts
@@ -1,3 +1,3 @@
-import BigNumber from "bignumber.js";
+import type BigNumberType from "bignumber.js";
 import { RoundingMode } from "../typing";
-export declare function expandRoundMode(roundMode: RoundingMode): BigNumber.RoundingMode;
+export declare function expandRoundMode(roundMode: RoundingMode): BigNumberType.RoundingMode;

--- a/typings/helpers/parseBigNumber.d.ts
+++ b/typings/helpers/parseBigNumber.d.ts
@@ -1,3 +1,2 @@
-import BigNumber from "bignumber.js";
 import { Numeric } from "typing";
-export declare function parseBigNumber(input: Numeric, raise?: boolean): BigNumber;
+export declare function parseBigNumber(input: Numeric, raise?: boolean): import("bignumber.js");

--- a/typings/helpers/roundNumber.d.ts
+++ b/typings/helpers/roundNumber.d.ts
@@ -1,9 +1,9 @@
-import BigNumber from "bignumber.js";
+import type BigNumberType from "bignumber.js";
 import { RoundingMode } from "../typing";
 type RoundingOptions = {
     roundMode: RoundingMode;
     precision: number | null;
     significant: boolean;
 };
-export declare function roundNumber(numeric: BigNumber, options: RoundingOptions): string;
+export declare function roundNumber(numeric: BigNumberType, options: RoundingOptions): string;
 export {};

--- a/typings/typing.d.ts
+++ b/typings/typing.d.ts
@@ -1,4 +1,4 @@
-import BigNumber from "bignumber.js";
+import type BigNumber from "bignumber.js";
 import { I18n } from "./I18n";
 export type MakePlural = (count: number, ordinal?: boolean) => string;
 export interface Dict {


### PR DESCRIPTION
🤖 Fixes #126.

## Problem

`numberToCurrency` (and anything using `formatNumber`) throws a `TypeError` in bundled environments (React Native/Metro, Webpack, Parcel) when `bignumber.js` resolves to v10.

bignumber.js v10 added a `"browser"` field to its `package.json` pointing at an IIFE build. Bundlers that honor the `"browser"` field load that build, but it assigns the constructor to `globalThis.BigNumber` instead of exporting it through CommonJS/ESM. The default import then resolves to an empty object, so `(0, bignumber_js_1.default)(NaN)` invokes `{}` as a function and throws.

Plain Node.js is unaffected because it resolves the `"main"` field, which still exports the constructor.

## Fix

Add a small `bigNumberResolver` wrapper that uses the imported value when it is callable and otherwise falls back to the global the IIFE installs, then route the helpers through it:

```ts
const resolvedBigNumber: typeof BigNumber =
  typeof BigNumber === "function"
    ? BigNumber
    : (globalThis as unknown as { BigNumber: typeof BigNumber }).BigNumber;
```

This keeps the existing `"bignumber.js": "*"` dependency (no version pin) and is bundler-agnostic — it adapts at runtime to whatever was resolved, rather than relying on resolver-field behavior, so it also covers Metro where a nested `browser` field remap is unreliable.

Files that reference `BigNumber` as a *type* (`num: BigNumber`, `BigNumber.RoundingMode`) keep a `import type` from `bignumber.js`, since types are compile-time and unaffected by runtime resolution.

## Tests

Added a regression test that reproduces the issue by mocking `bignumber.js` to an empty export with the constructor on the global, and asserts `numberToCurrency(1500)` returns `"$1,500.00"`. Verified it fails without the fallback.

Full suite green (178 tests), `tsc` and ESLint clean.